### PR TITLE
fix: apply default RestConfig values in NewRest

### DIFF
--- a/openmetadata-go-client/pkg/ometa/models.go
+++ b/openmetadata-go-client/pkg/ometa/models.go
@@ -7077,9 +7077,9 @@ type FieldBoost struct {
 
 // FieldChange defines model for FieldChange.
 type FieldChange struct {
-	Name     *string                 `json:"name,omitempty"`
-	NewValue *string                  `json:"newValue,omitempty"`
-	OldValue *string                  `json:"oldValue,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	NewValue *string `json:"newValue,omitempty"`
+	OldValue *string `json:"oldValue,omitempty"`
 }
 
 // FieldComparatorSource defines model for FieldComparatorSource.

--- a/openmetadata-go-client/pkg/ometa/rest.go
+++ b/openmetadata-go-client/pkg/ometa/rest.go
@@ -22,6 +22,8 @@ type Rest struct {
 
 // NewRest used to Instantiate a new Rest client
 func NewRest(restConfig *RestConfig) *Rest {
+	// Ensure defaults are applied even if RestConfig was created manually
+	restConfig.setDefaults()
 	bearerAuthString := fmt.Sprintf("%s %s", restConfig.AuthTokenMode, restConfig.AccessToken)
 
 	return &Rest{

--- a/openmetadata-go-client/pkg/ometa/rest_config.go
+++ b/openmetadata-go-client/pkg/ometa/rest_config.go
@@ -15,10 +15,10 @@ func (restConfig *RestConfig) setDefaults() {
 	if restConfig.APIVersion == "" {
 		restConfig.APIVersion = "v1"
 	}
-	if restConfig.Retry == 0 || restConfig.Retry < 0 {
+	if restConfig.Retry <= 0 {
 		restConfig.Retry = 3
 	}
-	if restConfig.RetryWait == 0 || restConfig.RetryWait < 0 {
+	if restConfig.RetryWait <= 0 {
 		restConfig.RetryWait = 30
 	}
 	if restConfig.RetryCodes == nil {

--- a/openmetadata-go-client/pkg/ometa/rest_test.go
+++ b/openmetadata-go-client/pkg/ometa/rest_test.go
@@ -68,3 +68,17 @@ func TestSetQueryParameter(t *testing.T) {
 	rest.setQueryParams(queryParams)
 	assert.Equal(t, rest.req.URL.RawQuery, "deleted=false&limit=10", "query parameters should be equal")
 }
+
+func TestNewRestSetsDefaults(t *testing.T) {
+	restConfig := &RestConfig{
+		BaseURL: "http://localhost:8080",
+	}
+	rest := NewRest(restConfig)
+
+	assert.NotNil(t, rest.restConfig, "config should not be nil")
+	assert.Equal(t, "http://localhost:8080", rest.restConfig.BaseURL, "BaseURL should be set")
+	assert.NotZero(t, rest.restConfig.APIVersion, "API version should have a default value")
+	assert.NotZero(t, rest.restConfig.Retry, "Retry should have a default value")
+	assert.NotZero(t, rest.restConfig.RetryWait, "RetryWait should have a default value")
+	assert.NotEmpty(t, rest.restConfig.RetryCodes, "RetryCodes should have a default")
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
Ensures RestConfig.setDefaults() is called in NewRest() so default values (e.g., retries, API version) are applied even when RestConfig is constructed manually. Prevents unexpected behavior from missing defaults.

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...
When I tried below code I got a nil reference and on reading the code I figured it wasn't setting the defaults and hence never making any backend api calls:

```go
	client = ometa.NewRest(&ometa.RestConfig{
		BaseURL:       "http://localhost:8585/api/v1",
		AuthTokenMode: "Bearer",
		AccessToken:   os.Getenv("OM_JWT_TOKEN"),
	})
```

As this logic in rest.go (`dispatchRequest func`) would still have retries as 0 so it wont run this code:

```go
	for retries > 0 {
		resp, err = http.DefaultClient.Do(rest.req)
		if err != nil {
			return nil, err
		}
		if resp.StatusCode >= 400 && shouldRetry(rest.restConfig.RetryCodes, *resp) {
			retries--
			time.Sleep(time.Duration(rest.restConfig.RetryWait) * time.Second)
			continue
		}
		break
	}
```
<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [X] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `[Fixes <issue-number>|MINOR]: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [X] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
